### PR TITLE
Add Gitpod config and dockerfile

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,6 @@
+FROM gitpod/workspace-full-vnc
+
+RUN sudo apt-get update \
+ && sudo apt-get install -y \
+    chromium-browser \
+ && sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+image:
+  file: .gitpod.dockerfile
+ports:
+  - port: 5900
+    onOpen: ignore
+  - port: 6080
+    onOpen: open-preview
+tasks:
+  - command: cd Gitpod && mvn clean verify

--- a/Gitpod/src/test/java/LaunchBrowser.java
+++ b/Gitpod/src/test/java/LaunchBrowser.java
@@ -17,8 +17,11 @@ public class LaunchBrowser {
 //		capabilities.setCapability("chrome.binary", "<Path to binary>");
 //		capabilities.setCapability(ChromeOptions.CAPABILITY, options);
 		WebDriver driver = null;
-        System.setProperty("webdriver.chrome.driver","chrome.exe");
-		driver = new ChromeDriver();
+        System.setProperty("webdriver.chrome.driver","/usr/bin/chromium-browser");
+        ChromeOptions chromeOptions = new ChromeOptions();
+        chromeOptions.addArguments("--disable-setuid-sandbox");
+        chromeOptions.addArguments("--no-sandbox");
+		driver = new ChromeDriver(chromeOptions);
         System.out.println("Step 1");
 	    System.out.println("Step 2");
 		driver.get("https://www.indeed.com/");


### PR DESCRIPTION
Hi @SravaniPilli31, thanks for your question in the [Gitpod community forum](https://spectrum.chat/gitpod/general/how-to-run-a-selenium-test-on-gitpod~e0e2bc2f-a77c-4aa9-afab-6c4fc5231949)!

I took a look at your repository, and made the following changes:
- Added a `.gitpod.yml` configuration file to set up relevant ports and tasks
- Added a `.gitpod.dockerfile` based on our VNC image, which also installs `chromium-browser`
- Changed the ChromeDriver binary from `chrome.exe` to `chromium-browser`
- Added the ChromeOptions `--no-sandbox` and `--disable-setuid-sandbox` to [disable Chrome's sandbox](https://github.com/Googlechrome/puppeteer/issues/290#issuecomment-322852784), because it cannot work in Ubuntu containers

However, for some reason, the ChromeOptions I added have no effect, and the demo still fails with the following error message:

```
The setuid sandbox is not running as root. Common causes:
  * An unprivileged process using ptrace on it, like a debugger.
  * A parent process set prctl(PR_SET_NO_NEW_PRIVS, ...)
Failed to move to new namespace: PID namespaces supported, Network namespace supported, but failed: errno = Operation not permitted
```

Again, the setuid sandbox can not work in Docker containers, because it requires privileges that are disabled by Docker for security reasons, but normally using `--no-sandbox` and/or `--disable-setuid-sandbox` successfully disables Chrome's sandbox.

Here, it seems that this is not the case. I'm not familiar enough with Selenium to know why, but I'll continue investigating this when I have more time.

Hopefully you'll still find these changes helpful though. 🙂 